### PR TITLE
Add cmd/vault-plugin-secrets-packet/main.go

### DIFF
--- a/cmd/vault-plugin-secrets-packet/main.go
+++ b/cmd/vault-plugin-secrets-packet/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+
+	"github.com/hashicorp/go-hclog"
+	packet "github.com/t0mk/vault-plugin-secrets-packet"
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/sdk/plugin"
+)
+
+func main() {
+	apiClientMeta := &api.PluginAPIClientMeta{}
+	flags := apiClientMeta.FlagSet()
+	flags.Parse(os.Args[1:])
+
+	tlsConfig := apiClientMeta.GetTLSConfig()
+	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
+
+	err := plugin.Serve(&plugin.ServeOpts{
+		BackendFactoryFunc: packet.Factory,
+		TLSProviderFunc:    tlsProviderFunc,
+	})
+	if err != nil {
+		logger := hclog.New(&hclog.LoggerOptions{})
+
+		logger.Error("plugin shutting down", "error", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This entire directory is ignored.

I built it with this Nix expr:

```
    { pkgs ? import <nixpkgs> {} }:
    pkgs.buildGoModule {
      name = "vault-plugin-secrets-packet";
      version = "0.0.1";
      src = ./vault-plugin-secrets-packet;
      modSha256 = "1q8ba5krq8a920gyvhdq4k7g15wnvchdyk1k4pl470xmxbsxcmji";
      subPackages = [ "cmd/vault-plugin-secrets-packet" ];
    }
```